### PR TITLE
Re-enable workflow in Safari

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: 12
@@ -17,7 +17,7 @@ jobs:
   # test-with-puppeteer:
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: actions/checkout@v1
+  #     - uses: actions/checkout@v2
   #     - uses: actions/setup-node@v1
   #       with:
   #         node-version: 12

--- a/.github/workflows/xbrowser.yml
+++ b/.github/workflows/xbrowser.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: 12
@@ -33,7 +33,7 @@ jobs:
       matrix:
         browser: [ie, firefox, chrome]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: 12
@@ -69,7 +69,7 @@ jobs:
     runs-on: macos-latest
     needs: [build]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: 12

--- a/.github/workflows/xbrowser.yml
+++ b/.github/workflows/xbrowser.yml
@@ -65,33 +65,27 @@ jobs:
       # Run
       - run: yarn test:karma:${{ matrix.browser }}
       - run: yarn test:e2e:${{ matrix.browser }}
-
-  # does not work: You must enable the 'Allow Remote Automation' option in Safari's Develop menu to control Safari via WebDriver
-  # e2e-safari:
-  #   runs-on: macos-latest
-  #   needs: [build]
-  #   steps:
-  #     - uses: actions/checkout@v1
-  #     - uses: actions/setup-node@v1
-  #       with:
-  #         node-version: 12
-  #     - uses: actions/cache@v1
-  #       with:
-  #         path: ~/.cache/yarn
-  #         key: xbrowser-mac-yarn-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}
-  #         restore-keys: |
-  #           xbrowser-mac-yarn-
-  #     - uses: actions/cache@v1
-  #       with:
-  #         path: dist
-  #         key: dist-${GITHUB_SHA}
-  #         restore-keys: |
-  #           dist-${GITHUB_SHA}
-  #     - run: yarn install
-  #     - run: |
-  #         defaults write com.apple.Safari IncludeDevelopMenu YES
-  #         defaults write com.apple.Safari AllowRemoteAutomation 1
-  #         sudo safaridriver --enable
-  #         safaridriver -p 0 &
-  #     # - run: yarn test:karma:safari
-  #     - run: yarn test:e2e:safari
+  e2e-safari:
+    runs-on: macos-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - uses: actions/cache@v1
+        with:
+          path: ~/.cache/yarn
+          key: xbrowser-mac-yarn-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}
+          restore-keys: |
+            xbrowser-mac-yarn-
+      - uses: actions/cache@v1
+        with:
+          path: dist
+          key: dist-${GITHUB_SHA}
+          restore-keys: |
+            dist-${GITHUB_SHA}
+      - run: yarn install
+      - run: sudo safaridriver --enable
+      # - run: yarn test:karma:safari
+      - run: yarn test:e2e:safari


### PR DESCRIPTION
We have been working on this issue for some time and wanted to let you know that the latest fixed image was recently deployed.